### PR TITLE
call loadfonts in .onAttach()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,15 +11,18 @@ Description: Tools to using fonts other than the standard PostScript fonts.
     symbols. See https://github.com/wch/extrafont for instructions and
     examples.
 Depends:
-    R (>= 2.15)
+    R (>= 2.15),
+    utils,
+    grDevices,
+    extrafontdb
 Imports:
-    extrafontdb,
     Rttf2pt1
 Suggests:
     fontcm
 License: GPL-2
 URL: https://github.com/wch/extrafont
 Collate:
+    'aaa.r'
     'load.r'
     'truetype.r'
     'utils.r'

--- a/R/aaa.r
+++ b/R/aaa.r
@@ -1,0 +1,8 @@
+.onAttach <- function(libname, pkgname) {
+    ## Load all fonts
+    loadfonts("pdf")
+    loadfonts("postscript")
+    if (.Platform$OS.type == "windows") {
+        loadfonts("win")
+    }
+}


### PR DESCRIPTION
It seems weird that loadfonts needs to be called everytime extrafont is used.  It seems that loadfonts should be a natural side-effect of loading the package, and should only have to be called if new fonts are imported during a session.  

I defined .onAttach to call loadfonts for all the relevant devices; this required adding some packages to depends.   Something else needs to be done in order to suppress, or provide a way to suppress messages. 

This may be a bad idea for reasons that I haven't considered, but if it can be done, it seems like the kind of outcome I'd expect as a user. 
