### PR TITLE
Allowing perl-type regexes for font_import file selection

### DIFF
--- a/R/font.r
+++ b/R/font.r
@@ -12,7 +12,7 @@
 #'
 #' @export
 font_import <- function(paths = NULL, recursive = TRUE, prompt = TRUE,
-                 pattern = NULL) {
+                 pattern = NULL, perl = FALSE) {
 
   if (prompt) {
     resp <- readline("Importing fonts may take a few minutes, depending on the number of fonts and the speed of the system.\nContinue? [y/n] ")
@@ -22,7 +22,7 @@ font_import <- function(paths = NULL, recursive = TRUE, prompt = TRUE,
     }
   }
 
-  ttf_import(paths, recursive, pattern)
+  ttf_import(paths, recursive, pattern, perl)
 }
 
 

--- a/R/truetype.r
+++ b/R/truetype.r
@@ -12,7 +12,7 @@
 #'
 #' @importFrom Rttf2pt1 which_ttf2pt1
 #' @export
-ttf_import <- function(paths = NULL, recursive = TRUE, pattern = NULL) {
+ttf_import <- function(paths = NULL, recursive = TRUE, pattern = NULL, perl = FALSE) {
 
   if (is.null(paths))  paths <- ttf_find_default_path()
 
@@ -21,7 +21,7 @@ ttf_import <- function(paths = NULL, recursive = TRUE, pattern = NULL) {
                                       ignore.case = TRUE))
 
   if (!is.null(pattern)) {
-    matchfiles <- grepl(pattern, basename(ttfiles))
+    matchfiles <- grepl(pattern, basename(ttfiles), perl = perl)
     ttfiles <- ttfiles[matchfiles]
   }
 
@@ -56,7 +56,7 @@ ttf_extract <- function(ttfiles) {
   message("Extracting .afm files from .ttf files...")
 
   # This stores information about the fonts
-  fontdata <- data.frame(fontfile = ttfiles, FontName = "", 
+  fontdata <- data.frame(fontfile = ttfiles, FontName = "",
                          stringsAsFactors = FALSE)
 
   outfiles <- file.path(metrics_path(),


### PR DESCRIPTION
It's helpful to have perl-type regexes to select font files to import.  I ran into this when I wanted to exclude a set of fonts from import to avoid errors due to fonts being read as duplicates. (e.g., importing no "Lato" fonts except "Lato-Regular").
