### PR TITLE
Add an all device to loadfonts()

### DIFF
--- a/R/aaa.r
+++ b/R/aaa.r
@@ -2,9 +2,5 @@
     packageStartupMessage("Registering fonts with R")
 
     ## Load all fonts
-    loadfonts("pdf", quiet = TRUE)
-    loadfonts("postscript", quiet = TRUE)
-    if (.Platform$OS.type == "windows") {
-        loadfonts("win", quiet = TRUE)
-    }
+    loadfonts("all", quiet = TRUE)
 }

--- a/R/load.r
+++ b/R/load.r
@@ -4,129 +4,178 @@
 #' postscript, or Windows bitmap output device. It must be run
 #' once in each R session.
 #'
-#' @param device The output device. Can be \code{"pdf"} (the default),
-#'   \code{"postscript"}, or \code{"win"}.
+#' @param device The output device. If \code{"all"}, then it will load \code{"pdf"}, \code{"postscript"}, and \code{"win"} (if on Windows).
 #' @param quiet If \code{FALSE}, print a status message as each font
 #'   is registered. If \code{TRUE}, don't print.
 #'
+#' @return A named list with up to three elments, one for each device
+#'   for which fonts were loaded. Each device element is a named list,
+#'   with an element for each family that was the function attempted to
+#'   register with that device. The value is \code{NULL} if the function did
+#'   not register the font family due to problems or because the font family
+#'   was already registered. If value is the return value of
+#'   \code{windowsFonts} for \code{"win"}, \code{\link{postscriptFonts}}
+#'   for \code{"postscript}}, and \code{\link{pdfFonts}} for \code{"pdf"}.
 #'
-#' @seealso \code{\link{embed_fonts}}
+#'
+#' @seealso \code{\link{embed_fonts}},
+#' #ifdef windows
+#'   \code{\link[grDevice]{windowsFont}}, \code{\link[grDevice]{windowsFonts}},
+#' #endif
+#'   \code{\link{postscriptFonts}},
+#'   \code{\link{pdfFonts}}, \code{\link{Type1Font}}.
 #' @import grDevices
 #' @export
-loadfonts <- function(device = "pdf", quiet = FALSE) {
-  fontdata <- fonttable()
+loadfonts <- function(device = c("all", "pdf", "postscript", "win"),
+                      quiet = FALSE) {
 
-  if (device == "pdf") {
-    # Get names of fonts that are already registered
-    cfonts   <- names(pdfFonts())
-    ffname   <- "pdfFonts"
-  } else if (device == "postscript") {
-    cfonts   <- names(postscriptFonts())
-    ffname   <- "postscriptFonts"
-  } else if (device == "win") {
-    cfonts   <- names(windowsFonts())
-    ffname   <- "windowsFonts"
-  } else {
-    stop("Unknown device: ", device)
-  }
-
-  fontfunc <- match.fun(ffname)
-
-  if (device %in% c("pdf", "postscript")) {
-    for (family in unique(fontdata$FamilyName)) {
-      if (family %in% cfonts) {
-        if (!quiet)
-          message(family, " already registered with ", ffname, "().")
-
-        next()
-      }
-
-      # All entries for this family
-      fd <- fontdata[fontdata$FamilyName == family, ]
-
-      regular     <- fd$afmfile[!fd$Bold & !fd$Italic]
-      bold        <- fd$afmfile[ fd$Bold & !fd$Italic]
-      italic      <- fd$afmfile[!fd$Bold &  fd$Italic]
-      bolditalic  <- fd$afmfile[ fd$Bold &  fd$Italic]
-
-      # There should be >1 entry for a given weight of a font only for weird
-      # fonts like Apple Braille. If found, skip this iteration of the loop.
-      if (length(regular) > 1  ||  length(bold)       > 1  ||
-          length(italic)  > 1  ||  length(bolditalic) > 1) {
-        if (!quiet) {
-          message("More than one version of regular/bold/italic found for ",
-                  family, ". Skipping setup for this font.")
-        }
-        next()
-      }
-
-      # There should be a regular entry for most every font. Exceptions
-      # include Brush Script MT.
-      if (length(regular) == 0) {
-        if (!quiet) {
-          message("No regular (non-bold, non-italic) version of ", family,
-                  ". Skipping setup for this font.")
-        }
-        next()
-      }
-
-      # If there aren't bold/italic entries, inherit the afm info from regular
-      if (length(bold)       == 0) bold       <- regular
-      if (length(italic)     == 0) italic     <- regular
-      if (length(bolditalic) == 0) bolditalic <- bold
-
-
-      # If there's an afmsymfile entry, use that as the symbol font
-      # Also check that all in this family have the same afmsymfile entry
-      if (!is.na(fd$afmsymfile[1]) && fd$afmsymfile[1] != ""  &&
-          all(fd$afmsymfile[1] == fd$afmsymfile)) {
-        symbol <- fd$afmsymfile[1]
-      } else {
-        symbol <- NULL
-      }
-
-      # Now we can register the font with R, with something like this:
-      # pdfFonts("Arial" = Type1Font("Arial",
-      #   file.path(afmpath, c("Arial.afm", "Arial Bold.afm",
-      #                        "Arial Italic.afm", "Arial Italic.afm"))))
-      if (!quiet)
-        message("Registering font with R using ", ffname, "(): ", family)
-
-      # Since 'family' is a string containing the name of the argument, we
-      # need to use do.call
-      args <- list()
-      args[[family]] <- Type1Font(family,
-                          metrics = file.path(metrics_path(),
-                            c(regular, bold, italic, bolditalic, symbol)))
-      do.call(fontfunc, args)
-    }
-
-  } else if (device == "win") {
-    for (family in unique(fontdata$FamilyName)) {
-      if (family %in% cfonts) {
-        if (!quiet)
-          message(family, " already registered with ", ffname, "().")
-
-        next()
-      }
-
-      # All entries for this family
-      fd <- fontdata[fontdata$FamilyName == family, ]
-
-      # Now we can register the font with R, with something like this:
-      # windowsFonts("Arial" = windowsFont("Arial"))
-      if (!quiet)
-        message("Registering font with R using ", ffname, "(): ", family)
-
-      # Since 'family' is a string containing the name of the argument, we
-      # need to use do.call
-      args <- list()
-      args[[family]] <- windowsFont(family)
-      do.call(fontfunc, args)
+  device <- match.arg(device)
+  if (device == "all") {
+    if (.Platform$OS.type == "windows") {
+      device <- c("pdf", "postscript", "win")
+    } else {
+      device <- c("pdf", "postscript")
     }
   }
+  ret <- list()
+  if ("win" %in% device) {
+    ret[["win"]] <- loadfonts_win(quiet = quiet)
+  }
+  if ("pdf" %in% device) {
+    ret[["pdf"]] <- loadfonts_pdf_ps(pdf = TRUE, quiet = quiet)
+  }
+  if ("postscript" %in% device) {
+    ret[["postscript"]] <- loadfonts_pdf_ps(pdf = FALSE, quiet = quiet)
+  }
+  invisible(ret)
 }
 
+register_family_win <- function(family, quiet = FALSE, cfonts = character()) {
+  ffname <- "windowsFonts"
+  fontfunc <- windowsFonts
+  # Now we can register the font with R, with something like this:
+  # windowsFonts("Arial" = windowsFont("Arial"))
+  if (family %in% cfonts) {
+    if (!quiet) {
+      message(family, " already registered with ", ffname, "().")
+    }
+    return(NULL)
+  }
+  if (!quiet) {
+    message("Registering font with R using ", ffname, "(): ", family)
+  }
+  # Since 'family' is a string containing the name of the argument, we
+  # need to use do.call
+  args <- list()
+  args[[family]] <- windowsFont(family)
+  do.call(fontfunc, args)
+}
+
+loadfonts_win <- function(quiet = FALSE) {
+  ffname <- "windowsFonts"
+  if (.Platform$OS.type != "windows") {
+    warning("OS is not Windows. No fonts registered with ", ffname, "().")
+    return(NULL)
+  }
+  fontdata <- fonttable()
+  # remove empty FamilyNames
+  fontdata <- fontdata[fontdata$FamilyName != "", , drop = FALSE]
+  cfonts <- names(windowsFonts())
+  families <- unique(fontdata$FamilyName)
+  lapply(families, register_family_win, cfonts = cfonts, quiet = quiet)
+}
+
+register_family_afm <- function(family, fd, pdf = TRUE, quiet = FALSE,
+                                cfonts = character()) {
+  if (pdf) {
+    ffname <- "pdfFont"
+    fontfunc <- pdfFonts
+  } else {
+    ffname <- "postscriptFont"
+    fontfunc <- postscriptFonts
+  }
+
+  if (family %in% cfonts) {
+    if (!quiet) {
+      message(family, " already registered with ", ffname, "().")
+    }
+    return(NULL)
+  }
+
+  regular     <- fd$afmfile[!fd$Bold & !fd$Italic]
+  bold        <- fd$afmfile[ fd$Bold & !fd$Italic]
+  italic      <- fd$afmfile[!fd$Bold &  fd$Italic]
+  bolditalic  <- fd$afmfile[ fd$Bold &  fd$Italic]
+
+  # There should be >1 entry for a given weight of a font only for weird
+  # fonts like Apple Braille. If found, skip this iteration of the loop.
+  if (length(regular) > 1  ||  length(bold)       > 1  ||
+      length(italic)  > 1  ||  length(bolditalic) > 1) {
+    if (!quiet) {
+      message("More than one version of regular/bold/italic found for ",
+              family, ". Skipping setup for this font.")
+    }
+    return(NULL)
+  }
+
+  # There should be a regular entry for most every font. Exceptions
+  # include Brush Script MT.
+  if (length(regular) == 0) {
+    if (!quiet) {
+      message("No regular (non-bold, non-italic) version of ", family,
+              ". Skipping setup for this font.")
+    }
+    return(NULL)
+  }
+
+  # If there aren't bold/italic entries, inherit the afm info from regular
+  if (length(bold)       == 0) bold       <- regular
+  if (length(italic)     == 0) italic     <- regular
+  if (length(bolditalic) == 0) bolditalic <- bold
+
+  # If there's an afmsymfile entry, use that as the symbol font
+  # Also check that all in this family have the same afmsymfile entry
+  if (!is.na(fd$afmsymfile[1]) && fd$afmsymfile[1] != ""  &&
+      all(fd$afmsymfile[1] == fd$afmsymfile)) {
+    symbol <- fd$afmsymfile[1]
+  } else {
+    symbol <- NULL
+  }
+
+  # Now we can register the font with R, with something like this:
+  # pdfFonts("Arial" = Type1Font("Arial",
+  #   file.path(afmpath, c("Arial.afm", "Arial Bold.afm",
+  #                        "Arial Italic.afm", "Arial Italic.afm"))))
+  if (!quiet) {
+    message("Registering font with R using ", ffname, "(): ", family)
+  }
+
+  # Since 'family' is a string containing the name of the argument, we
+  # need to use do.call
+  args <- list()
+  args[[family]] <-
+    Type1Font(family, metrics = file.path(metrics_path(),
+                                          c(regular, bold, italic,
+                                            bolditalic, symbol)))
+  do.call(fontfunc, args)
+}
+
+loadfonts_pdf_ps <- function(pdf = TRUE, quiet = FALSE) {
+  if (pdf) {
+    # Get names of fonts that are already registered
+    cfonts <- names(pdfFonts())
+  } else {
+    cfonts <- names(postscriptFonts())
+  }
+  fontdata <- fonttable()
+  # remove empty FamilyNames
+  fontdata <- fontdata[fontdata$FamilyName != "", , drop = FALSE]
+  # split fontdata into list of family data frames
+  family_data <- split(fontdata, fontdata$FamilyName)
+  mapply(register_family_afm, names(family_data), family_data,
+         MoreArgs = list(pdf = pdf, quiet = quiet, cfonts = cfonts),
+         SIMPLIFY = FALSE, USE.NAMES = TRUE)
+}
 
 #' Embeds fonts that are listed in the local Fontmap
 #'


### PR DESCRIPTION
Add an "all" device to `loadfonts()` which will load fonts for all devices (depending on the OS). This avoids having to call `loadfonts()` for each device (which is the typical use).  Additionally, there was some code refactoring done.

- Add an "all" device to loadfonts()
  which loads pdf, postscript, and windows (on Windows OS) only
- refactor code in loadfonts() to be more modular
- add warning
- loadfonts returns a list with information about which fonts were registered with each device