### PR TITLE
allow .pfa files as well as .pfb files

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,9 +1,10 @@
 Package: extrafont
 Title: Tools for Using Fonts
-Version: 0.17
+Version: 0.18
 Author: Winston Chang <winston@stdout.org>,
-Maintainer: Winston Chang <winston@stdout.org>
-Description: Tools to using fonts other than the standard PostScript fonts.
+Maintainer: Paul Murrell <paul@stat.auckland.ac.nz>
+Description: Paul Murrell's FORK for experimentation.
+    Tools to using fonts other than the standard PostScript fonts.
     This package makes it easy to use system TrueType fonts and with PDF or
     PostScript output files, and with bitmap output files in Windows. extrafont
     can also be used with fonts packaged specifically to be used with, such as

--- a/R/type1.r
+++ b/R/type1.r
@@ -23,12 +23,12 @@ type1_import <- function(pkgdir, pkgname = "") {
 
 
   # Match up with the .pfb files
-  pfbfile <- list.files(file.path(pkgdir, "fonts", "outlines"), "*.pfb",
+  pfbfile <- list.files(file.path(pkgdir, "fonts", "outlines"), "*.pf?",
                         full.names = TRUE, ignore.case = TRUE)
   
   # Set up the pfb data to merge
   pfbdata <- data.frame(fontfile = pfbfile,
-                        base = sub("\\.pfb$", "", basename(pfbfile)))
+                        base = sub("\\.pf.$", "", basename(pfbfile)))
 
   # Line up the afmfile and fontfile columns, matching on 'base'
   fontdata <- merge(fontdata, pfbdata)


### PR DESCRIPTION
Hi

For one of my packages ('courier') I made a small change to allow 'extrafont' to detect and use .pfa files as well as .pfb files.

Would you consider making this change in the real 'extrafont' ?

It's just a couple of lines (you can ignore the DESCRIPTION file)

Paul