### PR TITLE
Fonts added with Gnome Font Viewer

### DIFF
--- a/R/truetype.r
+++ b/R/truetype.r
@@ -136,6 +136,7 @@ ttf_find_default_path <- function() {
     paths <-
       c("/usr/share/fonts/",                    # Ubuntu/Debian/Arch/Gentoo
         "/usr/X11R6/lib/X11/fonts/TrueType/",   # RH 6
+        "~/.local/share/fonts/",                # Added with Gnome font viewer
         "~/.fonts/")                            # User fonts
     return(paths[file.exists(paths)])
 


### PR DESCRIPTION
HI,
Thanks for this nice package. Dealing with extra fonts is less painful.  
Now I dream to be able to install fonts on the system with command line from R, whatever the OS...

This PR is for Ubuntu users.  
On Ubuntu, when adding fonts graphically with Gnome Font Viewer, fonts are stored in `"~/.local/share/fonts/"`. I added this path in function `ttf_find_default_path()`.