### PR TITLE
add LOCALAPPDATA folder

### DIFF
--- a/R/truetype.r
+++ b/R/truetype.r
@@ -151,10 +151,8 @@ ttf_find_default_path <- function() {
 
   } else if (grepl("^mingw", R.version$os)) {
     paths <-
-      c(paste(Sys.getenv("SystemRoot"), "\\Fonts", sep=""),
-        file.path(
-          Sys.getenv()["LOCALAPPDATA"],
-          "Microsoft", "Windows", "Fonts")
+      c(file.path(Sys.getenv("SystemRoot"), "Fonts"),
+        file.path(Sys.getenv("LOCALAPPDATA"), "Microsoft", "Windows", "Fonts")
       )
     return(paths[file.exists(paths)])
   } else {

--- a/R/truetype.r
+++ b/R/truetype.r
@@ -150,7 +150,13 @@ ttf_find_default_path <- function() {
     return(paths[file.exists(paths)])
 
   } else if (grepl("^mingw", R.version$os)) {
-    return(paste(Sys.getenv("SystemRoot"), "\\Fonts", sep=""))
+    paths <-
+      c(paste(Sys.getenv("SystemRoot"), "\\Fonts", sep=""),
+        file.path(
+          Sys.getenv()["LOCALAPPDATA"],
+          "Microsoft", "Windows", "Fonts")
+      )
+    return(paths[file.exists(paths)])
   } else {
     stop("Unknown platform. Don't know where to look for truetype fonts. Sorry!")
   }


### PR DESCRIPTION
I made changes to add the `AppData/Local/Microsoft/Windows/Fonts` folder. This folder is used by Windows to install fonts without admin privileges. I tested the changes and did not had any problems. This merge addresses issue #68.