### PR TITLE
Uses native encoding for the path of the executable of Rttf2pt1

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,9 @@
+extrafont 0.xx
+----------------------------------------------------------------
+
+* Properly handles the encoding of the path of the executable of Rttf2pt1
+
+
 extrafont 0.17.0.9000
 ----------------------------------------------------------------
 

--- a/NEWS
+++ b/NEWS
@@ -1,8 +1,3 @@
-extrafont 0.xx
-----------------------------------------------------------------
-
-* Properly handles the encoding of the path of the executable of Rttf2pt1
-
 extrafont 0.17.0.9000
 ----------------------------------------------------------------
 
@@ -11,6 +6,9 @@ extrafont 0.17.0.9000
 
 * `loadfonts()` now has a new default device, `"all"`, which loads fonts for
   all devices. (Thanks to Jeff Arnold)
+
+* Properly handles the encoding of the path of the executable of Rttf2pt1.
+  (Thanks to Gabriel Magno)
 
 extrafont 0.17
 ----------------------------------------------------------------

--- a/NEWS
+++ b/NEWS
@@ -3,7 +3,6 @@ extrafont 0.xx
 
 * Properly handles the encoding of the path of the executable of Rttf2pt1
 
-
 extrafont 0.17.0.9000
 ----------------------------------------------------------------
 

--- a/R/truetype.r
+++ b/R/truetype.r
@@ -82,7 +82,7 @@ ttf_extract <- function(ttfiles) {
     #  ttf2pt1 -GfAe /Library/Fonts/Impact.ttf /out/path/Impact
     # The -GfAe options tell it to only create the .afm file, and not the
     # .t1a/pfa/pfb or .enc files. Run 'ttf2pt1 -G?' for more info.
-    ret <- system2(ttf2pt1, c(args, shQuote(ttfiles[i]), shQuote(tmpfiles[i])),
+    ret <- system2(enc2native(ttf2pt1), c(args, shQuote(ttfiles[i]), shQuote(tmpfiles[i])),
             stdout = TRUE, stderr = TRUE)
 
     fontnameidx <- grepl("^FontName ", ret)


### PR DESCRIPTION
## Bug Description
If I have a Windows user name with "special" characters like accents (e.g. `flávia`), the path where the executable of Rttf2pt1 is installed might have "special" characters as well. In the current version of `extrafont`, we would get this error when calling `font_import()`:
```
Scanning ttf files in C:\Windows\Fonts ...
Extracting .afm files from .ttf files...
C:\Windows\Fonts\AGENCYB.TTFError in system2(ttf2pt1, c(args, shQuote(ttfiles[i]), shQuote(tmpfiles[i])),  :
  '"C:/Users/flÃ¡via/Documents/R/win-library/4.0/Rttf2pt1/exec/ttf2pt1.exe"' not found
```
As we can see, the path of the executable was wrongly encoded (it should be `C:/Users/flávia/Documents/R/...`).

## Solution

I propose to convert the Rttf2pt1's path received from `which_ttf2pt1()` to the native encoding of the system, which should be the encoding of the path string passed to the `system2` function. We can do that by symply calling `enc2native`. If the string is already in the correct encoding (e.g. UTF-8 in Linux), it will not be modified and will keep its current encoding. Code sample:
```
system2(enc2native(ttf2pt1), ...)
```