### PR TITLE
Prefixed functions from grDevices and updated docs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,4 +21,4 @@ Suggests:
     fontcm
 License: GPL-2
 URL: https://github.com/wch/extrafont
-RoxygenNote: 6.0.1
+RoxygenNote: 7.1.1

--- a/R/load.r
+++ b/R/load.r
@@ -15,20 +15,19 @@
 #'   not register the font family due to problems or because the font family
 #'   was already registered. If value is the return value of
 #'   \code{windowsFonts} for \code{"win"}, \code{\link{postscriptFonts}}
-#'   for \code{"postscript}}, and \code{\link{pdfFonts}} for \code{"pdf"}.
+#'   for \code{"postscript"}, and \code{\link{pdfFonts}} for \code{"pdf"}.
 #'
 #'
 #' @seealso \code{\link{embed_fonts}},
 #' #ifdef windows
-#'   \code{\link[grDevice]{windowsFont}}, \code{\link[grDevice]{windowsFonts}},
+#'   \code{\link[grDevices]{windowsFont}}, \code{\link[grDevices]{windowsFonts}},
 #' #endif
-#'   \code{\link{postscriptFonts}},
-#'   \code{\link{pdfFonts}}, \code{\link{Type1Font}}.
+#'   \code{\link[grDevices]{postscriptFonts}},
+#'   \code{\link[grDevices]{pdfFonts}}, \code{\link[grDevices]{Type1Font}}.
 #' @import grDevices
 #' @export
 loadfonts <- function(device = c("all", "pdf", "postscript", "win"),
                       quiet = FALSE) {
-
   device <- match.arg(device)
   if (device == "all") {
     if (.Platform$OS.type == "windows") {
@@ -52,7 +51,7 @@ loadfonts <- function(device = c("all", "pdf", "postscript", "win"),
 
 register_family_win <- function(family, quiet = FALSE, cfonts = character()) {
   ffname <- "windowsFonts"
-  fontfunc <- windowsFonts
+  fontfunc <- grDevices::windowsFonts
   # Now we can register the font with R, with something like this:
   # windowsFonts("Arial" = windowsFont("Arial"))
   if (family %in% cfonts) {
@@ -67,7 +66,7 @@ register_family_win <- function(family, quiet = FALSE, cfonts = character()) {
   # Since 'family' is a string containing the name of the argument, we
   # need to use do.call
   args <- list()
-  args[[family]] <- windowsFont(family)
+  args[[family]] <- grDevices::windowsFont(family)
   do.call(fontfunc, args)
 }
 
@@ -80,7 +79,7 @@ loadfonts_win <- function(quiet = FALSE) {
   fontdata <- fonttable()
   # remove empty FamilyNames
   fontdata <- fontdata[fontdata$FamilyName != "", , drop = FALSE]
-  cfonts <- names(windowsFonts())
+  cfonts <- names(grDevices::windowsFonts())
   families <- unique(fontdata$FamilyName)
   lapply(families, register_family_win, cfonts = cfonts, quiet = quiet)
 }
@@ -89,10 +88,10 @@ register_family_afm <- function(family, fd, pdf = TRUE, quiet = FALSE,
                                 cfonts = character()) {
   if (pdf) {
     ffname <- "pdfFont"
-    fontfunc <- pdfFonts
+    fontfunc <- grDevices::pdfFonts
   } else {
     ffname <- "postscriptFont"
-    fontfunc <- postscriptFonts
+    fontfunc <- grDevices::postscriptFonts
   }
 
   if (family %in% cfonts) {
@@ -102,18 +101,20 @@ register_family_afm <- function(family, fd, pdf = TRUE, quiet = FALSE,
     return(NULL)
   }
 
-  regular     <- fd$afmfile[!fd$Bold & !fd$Italic]
-  bold        <- fd$afmfile[ fd$Bold & !fd$Italic]
-  italic      <- fd$afmfile[!fd$Bold &  fd$Italic]
-  bolditalic  <- fd$afmfile[ fd$Bold &  fd$Italic]
+  regular <- fd$afmfile[!fd$Bold & !fd$Italic]
+  bold <- fd$afmfile[fd$Bold & !fd$Italic]
+  italic <- fd$afmfile[!fd$Bold & fd$Italic]
+  bolditalic <- fd$afmfile[fd$Bold & fd$Italic]
 
   # There should be >1 entry for a given weight of a font only for weird
   # fonts like Apple Braille. If found, skip this iteration of the loop.
-  if (length(regular) > 1  ||  length(bold)       > 1  ||
-      length(italic)  > 1  ||  length(bolditalic) > 1) {
+  if (length(regular) > 1 || length(bold) > 1 ||
+    length(italic) > 1 || length(bolditalic) > 1) {
     if (!quiet) {
-      message("More than one version of regular/bold/italic found for ",
-              family, ". Skipping setup for this font.")
+      message(
+        "More than one version of regular/bold/italic found for ",
+        family, ". Skipping setup for this font."
+      )
     }
     return(NULL)
   }
@@ -122,21 +123,23 @@ register_family_afm <- function(family, fd, pdf = TRUE, quiet = FALSE,
   # include Brush Script MT.
   if (length(regular) == 0) {
     if (!quiet) {
-      message("No regular (non-bold, non-italic) version of ", family,
-              ". Skipping setup for this font.")
+      message(
+        "No regular (non-bold, non-italic) version of ", family,
+        ". Skipping setup for this font."
+      )
     }
     return(NULL)
   }
 
   # If there aren't bold/italic entries, inherit the afm info from regular
-  if (length(bold)       == 0) bold       <- regular
-  if (length(italic)     == 0) italic     <- regular
+  if (length(bold) == 0) bold <- regular
+  if (length(italic) == 0) italic <- regular
   if (length(bolditalic) == 0) bolditalic <- bold
 
   # If there's an afmsymfile entry, use that as the symbol font
   # Also check that all in this family have the same afmsymfile entry
-  if (!is.na(fd$afmsymfile[1]) && fd$afmsymfile[1] != ""  &&
-      all(fd$afmsymfile[1] == fd$afmsymfile)) {
+  if (!is.na(fd$afmsymfile[1]) && fd$afmsymfile[1] != "" &&
+    all(fd$afmsymfile[1] == fd$afmsymfile)) {
     symbol <- fd$afmsymfile[1]
   } else {
     symbol <- NULL
@@ -154,18 +157,22 @@ register_family_afm <- function(family, fd, pdf = TRUE, quiet = FALSE,
   # need to use do.call
   args <- list()
   args[[family]] <-
-    Type1Font(family, metrics = file.path(metrics_path(),
-                                          c(regular, bold, italic,
-                                            bolditalic, symbol)))
+    Type1Font(family, metrics = file.path(
+      metrics_path(),
+      c(
+        regular, bold, italic,
+        bolditalic, symbol
+      )
+    ))
   do.call(fontfunc, args)
 }
 
 loadfonts_pdf_ps <- function(pdf = TRUE, quiet = FALSE) {
   if (pdf) {
     # Get names of fonts that are already registered
-    cfonts <- names(pdfFonts())
+    cfonts <- names(grDevices::pdfFonts())
   } else {
-    cfonts <- names(postscriptFonts())
+    cfonts <- names(grDevices::postscriptFonts())
   }
   fontdata <- fonttable()
   # remove empty FamilyNames
@@ -173,8 +180,9 @@ loadfonts_pdf_ps <- function(pdf = TRUE, quiet = FALSE) {
   # split fontdata into list of family data frames
   family_data <- split(fontdata, fontdata$FamilyName)
   mapply(register_family_afm, names(family_data), family_data,
-         MoreArgs = list(pdf = pdf, quiet = quiet, cfonts = cfonts),
-         SIMPLIFY = FALSE, USE.NAMES = TRUE)
+    MoreArgs = list(pdf = pdf, quiet = quiet, cfonts = cfonts),
+    SIMPLIFY = FALSE, USE.NAMES = TRUE
+  )
 }
 
 #' Embeds fonts that are listed in the local Fontmap
@@ -188,20 +196,21 @@ loadfonts_pdf_ps <- function(pdf = TRUE, quiet = FALSE) {
 #'
 #' \dontrun{
 #' loadfonts()
-#' pdf('fonttest.pdf')
+#' pdf("fonttest.pdf")
 #' library(ggplot2)
 #'
-#' p <- ggplot(mtcars, aes(x=wt, y=mpg)) + geom_point()
+#' p <- ggplot(mtcars, aes(x = wt, y = mpg)) +
+#'   geom_point()
 #'
 #' # Run only the code below that is appropriate for your system
 #' # On Mac and Windows, Impact should be available
-#' p + opts(axis.title.x=theme_text(size=16, family="Impact", colour="red"))
+#' p + opts(axis.title.x = theme_text(size = 16, family = "Impact", colour = "red"))
 #'
 #' # On Linux, Purisa may be available
-#' p + opts(axis.title.x=theme_text(size=16, family="Purisa", colour="red"))
+#' p + opts(axis.title.x = theme_text(size = 16, family = "Purisa", colour = "red"))
 #' dev.off()
 #'
-#' embed_fonts('fonttest.pdf', outfile='fonttest-embed.pdf')
+#' embed_fonts("fonttest.pdf", outfile = "fonttest-embed.pdf")
 #' }
 #'
 #' @seealso \code{\link{loadfonts}}
@@ -243,8 +252,11 @@ embed_fonts <- function(file, format, outfile = file, options = "") {
     fontmap <- tmpdir
   }
 
-  embedFonts(file = file, format = format, outfile = outfile,
+  embedFonts(
+    file = file, format = format, outfile = outfile,
     options = paste(
       paste("-I", shQuote(fontmap), sep = ""),
-      options))
+      options
+    )
+  )
 }

--- a/man/extrafont.Rd
+++ b/man/extrafont.Rd
@@ -4,7 +4,6 @@
 \name{extrafont}
 \alias{extrafont}
 \alias{package-extrafont}
-\alias{extrafont-package}
 \title{extrafont package}
 \description{
 This package is used for using and embedding fonts other than the

--- a/man/font_import.Rd
+++ b/man/font_import.Rd
@@ -4,8 +4,7 @@
 \alias{font_import}
 \title{Import system fonts}
 \usage{
-font_import(paths = NULL, recursive = TRUE, prompt = TRUE,
-  pattern = NULL)
+font_import(paths = NULL, recursive = TRUE, prompt = TRUE, pattern = NULL)
 }
 \arguments{
 \item{paths}{A vector of directories to search in. (Default is to auto-detect based on OS)}

--- a/man/loadfonts.Rd
+++ b/man/loadfonts.Rd
@@ -4,14 +4,23 @@
 \alias{loadfonts}
 \title{Reads the fonttable database and registers those fonts with R}
 \usage{
-loadfonts(device = "pdf", quiet = FALSE)
+loadfonts(device = c("all", "pdf", "postscript", "win"), quiet = FALSE)
 }
 \arguments{
-\item{device}{The output device. Can be \code{"pdf"} (the default),
-\code{"postscript"}, or \code{"win"}.}
+\item{device}{The output device. If \code{"all"}, then it will load \code{"pdf"}, \code{"postscript"}, and \code{"win"} (if on Windows).}
 
 \item{quiet}{If \code{FALSE}, print a status message as each font
 is registered. If \code{TRUE}, don't print.}
+}
+\value{
+A named list with up to three elments, one for each device
+  for which fonts were loaded. Each device element is a named list,
+  with an element for each family that was the function attempted to
+  register with that device. The value is \code{NULL} if the function did
+  not register the font family due to problems or because the font family
+  was already registered. If value is the return value of
+  \code{windowsFonts} for \code{"win"}, \code{\link{postscriptFonts}}
+  for \code{"postscript"}, and \code{\link{pdfFonts}} for \code{"pdf"}.
 }
 \description{
 This registers fonts so that they can be used with the pdf,
@@ -19,5 +28,10 @@ postscript, or Windows bitmap output device. It must be run
 once in each R session.
 }
 \seealso{
-\code{\link{embed_fonts}}
+\code{\link{embed_fonts}},
+#ifdef windows
+  \code{\link[grDevices]{windowsFont}}, \code{\link[grDevices]{windowsFonts}},
+#endif
+  \code{\link{postscriptFonts}},
+  \code{\link{pdfFonts}}, \code{\link{Type1Font}}.
 }


### PR DESCRIPTION
I noticed some discussion in issue #44 that functions in the package grDevices didn't have `grDevices::` prefixes, which caused problems in checks for downstream package (mine included) that use extrafont. This update seems to play well with `devtools::check()`.

I also found and fixed a typo in the roxygen2 docs and regenerated the documentation.

Please let me know if there are any other checks you'd like me to perform.
