### PR TITLE
Bug fix in type1.r

### DIFF
--- a/R/type1.r
+++ b/R/type1.r
@@ -28,7 +28,7 @@ type1_import <- function(pkgdir, pkgname = "") {
   
   # Set up the pfb/pfa data to merge
   pfbdata <- data.frame(fontfile = pfbfile,
-                        base = sub("\\.pf?$", "", basename(pfbfile)))
+                        base = sub("\\.pf.$", "", basename(pfbfile)))
 
   # Line up the afmfile and fontfile columns, matching on 'base'
   fontdata <- merge(fontdata, pfbdata)


### PR DESCRIPTION
Extrafont: Bug + Suggested Fix

Here are details of a bug in extrafont (issue #94), along with a suggested fix.

Summary:  incorrect regex.

Location: lines 30-31, type1_import function, in type1.r.
   
Details: The statement spanning lines 30 and 31 of the type1_import function in type1.r is intended to trim .pfb and .pfa file extensions. The sub function used in that statement expects regex, but an OS command line style wildcard operator is passed instead (? acts as a quantifier, not wildcard in regex). The result is that the file extensions aren't trimmed, and the merge operation called soon after doesn't work as intended, typically (and undesirably) deleting all rows from the fontdata data frame. See below for an example:

   Existing:  sub("\\.pf?$", "", basename("cmsyase.pfb"))
      Returns: "cmsyase.pfb"

   Proposed:  sub("\\.pf.$", "", basename("cmsyase.pfb"))
      Returns: "cmsyase"

Fix: Changed one character. Details are given below.

Old statement: pfbdata <- data.frame(fontfile = pfbfile,
                     base = sub("\\.pf?$", "", basename(pfbfile)))

New statement: pfbdata <- data.frame(fontfile = pfbfile,
                     base = sub("\\.pf.$", "", basename(pfbfile)))

N.B. This fixes currently open issue #94.