### PR TITLE
specify remote for Rttf2pt1

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,6 +16,8 @@ Imports:
     grDevices,
     utils,
     Rttf2pt1
+Remotes:
+    Rttf2pt1=github::wch/Rttf2pt1
 Suggests:
     fontcm
 License: GPL-2


### PR DESCRIPTION
As Rttf2pt1 is currently not on CRAN, specifying the github repo in Remotes simplifies installation of extrafont and everything depending on it.